### PR TITLE
some variables of maps fragment have been relocated to maps viewModel

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,7 +5,7 @@
       <map>
         <entry key="..\:/Users/jefferson/AndroidStudioProjects/PruebaAndroidTL/app/src/main/res/layout/activity_main.xml" value="0.19322916666666667" />
         <entry key="..\:/Users/jefferson/AndroidStudioProjects/PruebaAndroidTL/app/src/main/res/layout/fragment_home.xml" value="0.17760416666666667" />
-        <entry key="..\:/Users/jefferson/AndroidStudioProjects/PruebaAndroidTL/app/src/main/res/layout/fragment_maps1.xml" value="0.25" />
+        <entry key="..\:/Users/jefferson/AndroidStudioProjects/PruebaAndroidTL/app/src/main/res/layout/fragment_maps1.xml" value="0.33" />
         <entry key="..\:/Users/jefferson/AndroidStudioProjects/PruebaAndroidTL/app/src/main/res/layout/fragment_maps_test.xml" value="0.3265625" />
         <entry key="..\:/Users/jefferson/AndroidStudioProjects/PruebaAndroidTL/app/src/main/res/layout/fragment_movie_detail.xml" value="0.25" />
         <entry key="..\:/Users/jefferson/AndroidStudioProjects/PruebaAndroidTL/app/src/main/res/layout/fragment_movie_list.xml" value="0.25" />

--- a/app/src/main/java/com/myapps/pruebaandroidtl/mapsfeature/ui/fragments/HomeFragment.kt
+++ b/app/src/main/java/com/myapps/pruebaandroidtl/mapsfeature/ui/fragments/HomeFragment.kt
@@ -1,14 +1,12 @@
 package com.myapps.pruebaandroidtl.mapsfeature.ui.fragments
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
-import com.myapps.pruebaandroidtl.R
 import com.myapps.pruebaandroidtl.databinding.FragmentHomeBinding
-import com.myapps.pruebaandroidtl.databinding.FragmentRouteInfoBinding
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -20,7 +18,7 @@ class HomeFragment : Fragment() {
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         _binding = FragmentHomeBinding.inflate(inflater, container, false)
         return binding.root
     }

--- a/app/src/main/java/com/myapps/pruebaandroidtl/mapsfeature/ui/fragments/Maps1Fragment.kt
+++ b/app/src/main/java/com/myapps/pruebaandroidtl/mapsfeature/ui/fragments/Maps1Fragment.kt
@@ -3,13 +3,13 @@ package com.myapps.pruebaandroidtl.mapsfeature.ui.fragments
 import android.Manifest
 import android.content.pm.PackageManager
 import android.location.Geocoder
-import android.net.RouteInfo
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -27,6 +27,10 @@ import com.myapps.pruebaandroidtl.databinding.FragmentMaps1Binding
 import com.myapps.pruebaandroidtl.mapsfeature.domain.models.RouteModel
 import com.myapps.pruebaandroidtl.mapsfeature.ui.viewmodels.MapsViewModel
 import com.myapps.pruebaandroidtl.utils.StateResult
+import com.myapps.pruebaandroidtl.utils.constants.CUSTOM_ZOOM
+import com.myapps.pruebaandroidtl.utils.constants.ONE_INT
+import com.myapps.pruebaandroidtl.utils.constants.ROUTE_LINE_WIDTH
+import com.myapps.pruebaandroidtl.utils.constants.ZERO_INT
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -38,13 +42,11 @@ class Maps1Fragment : Fragment() {
 
     private lateinit var fusedLocationProviderClient: FusedLocationProviderClient
 
-    private var start: LatLng? = null
-
-    private var end: LatLng? = null
-
-    private var poly: Polyline? = null
-
     private var mRoute: RouteModel? = null
+
+    private var polyLineOptions: PolylineOptions? = null
+
+    private var mPolyLine: Polyline? = null
 
     private val viewModel by viewModels<MapsViewModel>()
 
@@ -55,19 +57,14 @@ class Maps1Fragment : Fragment() {
     private val callback = OnMapReadyCallback { googleMap ->
         map = googleMap
         map?.setOnMapClickListener { location ->
-            actualizePolyLine()
-            end = location
-            map?.animateCamera(CameraUpdateFactory.newLatLngZoom(location, 14f),null)
-            drawNewMarker(location)
-            binding.btnSeeRouteInfo.isEnabled = true
+            viewModel.saveEndLocation(location)
+            map?.clear()
+            drawMyLocationMarker()
+            drawEndLocationMarker()
             createRoute()
+            drawPolyLine()
         }
         locationPermission()
-    }
-
-    private fun actualizePolyLine(){
-        poly?.remove()
-        poly?.let{poly = null}
     }
 
     private var _binding: FragmentMaps1Binding? = null
@@ -84,17 +81,16 @@ class Maps1Fragment : Fragment() {
         binding.mapView.getMapAsync(callback)
         geocoder = Geocoder(requireContext())
         fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(requireActivity())
-
         setupObservers()
         setupListeners()
+        drawEndLocationMarker()
     }
 
     private fun setupListeners() {
         binding.btnSeeRouteInfo.setOnClickListener {
             mRoute?.let {
                 findNavController().navigate(Maps1FragmentDirections.actionMaps1FragmentToRouteInfoFragment(
-                    floatArrayOf(it.distance.toFloat(), it.duration.toFloat())
-                ))
+                    floatArrayOf(it.distance.toFloat(), it.duration.toFloat())))
             }
         }
     }
@@ -104,30 +100,79 @@ class Maps1Fragment : Fragment() {
             mRoute = route.data
             when(route){
                 is StateResult.Success -> {
-                    val polyLineOptions = PolylineOptions()
+                    polyLineOptions= PolylineOptions()
                     route.data?.coordinates?.forEach {
-                        polyLineOptions.add(LatLng(it[1], it[0]))
+                        polyLineOptions?.add(LatLng(it[ONE_INT], it[ZERO_INT]))
                     }
-                    poly = map?.addPolyline(polyLineOptions)
+                    polyLineOptions?.let {
+                        it
+                            .width(ROUTE_LINE_WIDTH)
+                            .color(ContextCompat.getColor(requireContext(),R.color.purple_700))
+                        viewModel.savePolyLineOptions(it)
+                    }
                 }
                 else -> {
-                    Toast.makeText(requireContext(),"no se ha encontrado la ruta", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(requireContext(),getString(R.string.route_not_found), Toast.LENGTH_SHORT).show()
                 }
             }
         }
     }
 
-    private fun drawNewMarker(location: LatLng){
-        val address = geocoder.getFromLocation(location.latitude, location.longitude,  2)[0].getAddressLine(0)
-        binding.tvTargetLocationAddress.text = getString(R.string.label_to, address)
-        createMarker(location,address)
-        Toast.makeText(requireContext(), address, Toast.LENGTH_SHORT).show()
+    private fun drawPolyLine() {
+        viewModel.polylineOptions.observe(viewLifecycleOwner){
+            it?.let {poly ->
+                removeOldPolyLine()
+                mPolyLine = map?.addPolyline(poly)
+            }
+        }
     }
 
-    private fun createRoute(){
-        start?.let {
-            end?.let {
-                viewModel.getRoute(start as LatLng, end as LatLng)
+    private fun removeOldPolyLine() {
+        mPolyLine?.remove()
+        mPolyLine = null
+    }
+
+    private fun drawMyLocationMarker() {
+        viewModel.startLocation.observe(viewLifecycleOwner) { myLocation ->
+            myLocation?.let {
+                drawNewMarker(it)
+                val address = getAddress(it)
+                binding.tvMyLocationAddress.text = getString(R.string.label_from, address)
+            }
+        }
+    }
+
+    private fun drawEndLocationMarker() {
+        viewModel.endLocation.observe(viewLifecycleOwner){ myLocation ->
+            binding.btnSeeRouteInfo.isEnabled = true
+            myLocation?.let {
+                drawNewMarker(it)
+                val address = getAddress(it)
+                binding.tvTargetLocationAddress.text = getString(R.string.label_from, address)
+            }
+        }
+    }
+
+    private fun drawNewMarker(location: LatLng) {
+        val address = getAddress(location)
+        val marker = MarkerOptions().position(location).title(address)
+        map?.addMarker(marker)
+    }
+
+    private fun getAddress(location: LatLng?): String {
+        location?.let {
+            return geocoder.getFromLocation(it.latitude, it.longitude, ONE_INT)[ZERO_INT].getAddressLine(ZERO_INT)
+        } ?: return getString(R.string.wrong_location)
+    }
+
+    private fun createRoute() {
+        viewModel.startLocation.observe(viewLifecycleOwner) { itStart ->
+            itStart?.let { startLocation ->
+                viewModel.endLocation.observe(viewLifecycleOwner) { itEnd ->
+                    itEnd?.let { endLocation ->
+                        viewModel.getRoute(startLocation, endLocation)
+                    }
+                }
             }
         }
     }
@@ -139,17 +184,13 @@ class Maps1Fragment : Fragment() {
             map?.isMyLocationEnabled = false
             Toast.makeText(
                 requireContext(),
-                "Ve a ajustes y acepta los permisos",
+                getString(R.string.go_to_settings),
                 Toast.LENGTH_SHORT
             ).show()
         }
+        createRoute()
+        drawPolyLine()
     }
-
-    private fun createMarker(location: LatLng, address: String) {
-        val marker = MarkerOptions().position(location).title(address)
-        map?.addMarker(marker)
-    }
-
 
 
     private fun locationPermission() {
@@ -158,30 +199,27 @@ class Maps1Fragment : Fragment() {
             fusedLocationProviderClient.lastLocation.addOnSuccessListener(requireActivity()) {
                 val location = LatLng(it.latitude,it.longitude)
                 setMyLocationOnMap(location)
-                map?.animateCamera(CameraUpdateFactory.newLatLngZoom(location, 14f),2000,null)
             }
             return
-        }else{
+        }else {
             requestLocationPermission()
         }
-
     }
 
-    private fun setMyLocationOnMap(location: LatLng?){
+    private fun setMyLocationOnMap(location: LatLng?) {
         location?.let{
-            start = it
-            val address = geocoder.getFromLocation(location.latitude, location.longitude,1)[0].getAddressLine(0)
-            binding.tvMyLocationAddress.text = getString(R.string.label_from, address)
-            createMarker(location, address)
+            viewModel.saveStartPoint(it)
+            map?.animateCamera(CameraUpdateFactory.newLatLngZoom(it, CUSTOM_ZOOM),null)
+            drawMyLocationMarker()
+            drawEndLocationMarker()
         }
     }
 
-    private fun requestLocationPermission(){
+    private fun requestLocationPermission() {
         if (ActivityCompat.shouldShowRequestPermissionRationale(requireActivity(), Manifest.permission.ACCESS_FINE_LOCATION)){
-            Toast.makeText(requireContext(),"Ve a ajustes y acepta los permisos",Toast.LENGTH_SHORT).show()
+            Toast.makeText(requireContext(),getString(R.string.go_to_settings),Toast.LENGTH_SHORT).show()
         }else{
             ActivityCompat.requestPermissions(requireActivity(), arrayOf(Manifest.permission.ACCESS_FINE_LOCATION), REQUEST_CODE_LOCATION)
-
         }
     }
 

--- a/app/src/main/java/com/myapps/pruebaandroidtl/mapsfeature/ui/fragments/RouteInfoFragment.kt
+++ b/app/src/main/java/com/myapps/pruebaandroidtl/mapsfeature/ui/fragments/RouteInfoFragment.kt
@@ -35,9 +35,9 @@ class RouteInfoFragment : Fragment() {
     private fun setupView() {
         with(binding){
             safeArgs?.let {
-                val distance = String.format("%.1f",it.time?.get(0)?.div(1000))
+                val distance = String.format("%.1f",it.routeInfo?.get(0)?.div(1000))
                 tvDistance.text = getString(R.string.label_distance, distance.toString())
-                val time = it.time?.get(1)?.div(60)
+                val time = it.routeInfo?.get(1)?.div(60)
                 tvTime.text = getString(R.string.label_time, String.format("%.1f", time))
             }
 

--- a/app/src/main/java/com/myapps/pruebaandroidtl/mapsfeature/ui/viewmodels/MapsViewModel.kt
+++ b/app/src/main/java/com/myapps/pruebaandroidtl/mapsfeature/ui/viewmodels/MapsViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.Polyline
+import com.google.android.gms.maps.model.PolylineOptions
 import com.myapps.pruebaandroidtl.mapsfeature.domain.models.RouteModel
 import com.myapps.pruebaandroidtl.mapsfeature.domain.usecases.GetRoutesUseCase
 import com.myapps.pruebaandroidtl.utils.StateResult
@@ -19,12 +21,47 @@ class MapsViewModel @Inject constructor(private val getRoutesUseCase: GetRoutesU
     private val _route = MutableLiveData<StateResult<RouteModel>>()
     val route: LiveData<StateResult<RouteModel>> = _route
 
-    fun getRoute(start:LatLng, end: LatLng){
-        viewModelScope.launch (Dispatchers.IO){
+    private val _startLocation = MutableLiveData<LatLng?>()
+    val startLocation: LiveData<LatLng?> = _startLocation
+
+    private val _endLocation = MutableLiveData<LatLng?>()
+    val endLocation: LiveData<LatLng?> = _endLocation
+
+    private val _newRouteLine = MutableLiveData<Polyline?>()
+    val newRouteLine: LiveData<Polyline?> = _newRouteLine
+
+    private val _oldRouteLine = MutableLiveData<Polyline?>()
+    val oldRouteLine: LiveData<Polyline?> = _oldRouteLine
+
+    private val _polyLineOptions = MutableLiveData<PolylineOptions?>()
+    val polylineOptions: LiveData<PolylineOptions?> = _polyLineOptions
+
+    fun getRoute(start:LatLng, end: LatLng) {
+        viewModelScope.launch (Dispatchers.IO) {
             getRoutesUseCase(start, end).let {
                 _route.postValue(it)
             }
         }
+    }
+
+    fun saveStartPoint(startLocation: LatLng) {
+        _startLocation.value = startLocation
+    }
+
+    fun saveEndLocation(endLocation: LatLng) {
+        _endLocation.value = endLocation
+    }
+
+    fun saveNewRouteLine(poli: Polyline?) {
+        _newRouteLine.value = poli
+    }
+
+    fun saveOldRouteLine(poli: Polyline?) {
+        _oldRouteLine.value = poli
+    }
+
+    fun savePolyLineOptions(polylineOptions: PolylineOptions) {
+        _polyLineOptions.value = polylineOptions
     }
 
 

--- a/app/src/main/java/com/myapps/pruebaandroidtl/moviesfeature/data/api/TheMovieDataBaseApi.kt
+++ b/app/src/main/java/com/myapps/pruebaandroidtl/moviesfeature/data/api/TheMovieDataBaseApi.kt
@@ -2,7 +2,7 @@ package com.myapps.pruebaandroidtl.moviesfeature.data.api
 
 import com.myapps.pruebaandroidtl.mapsfeature.data.mapsdto.RouteDto
 import com.myapps.pruebaandroidtl.moviesfeature.data.dto.PopularMoviesDto
-import com.myapps.pruebaandroidtl.utils.constants.INITIAL_PAGE
+import com.myapps.pruebaandroidtl.utils.constants.ONE_INT
 import com.myapps.pruebaandroidtl.utils.constants.POPULAR_MOVIES_ENDPOINT
 import com.myapps.pruebaandroidtl.utils.constants.TMDB_API_KEY
 import retrofit2.Response
@@ -17,7 +17,7 @@ interface TheMovieDataBaseApi {
         @Query("api_key")
         api_key: String = TMDB_API_KEY,
         @Query("page")
-        page: Int = INITIAL_PAGE
+        page: Int = ONE_INT
     ) : Response<PopularMoviesDto>
 
     @GET(POPULAR_MOVIES_ENDPOINT)
@@ -25,7 +25,7 @@ interface TheMovieDataBaseApi {
         @Query("api_key")
         api_key: String = TMDB_API_KEY,
         @Query("page")
-        page: Int = INITIAL_PAGE
+        page: Int = ONE_INT
     ) : PopularMoviesDto
 
     @GET

--- a/app/src/main/java/com/myapps/pruebaandroidtl/moviesfeature/data/paging/MoviesRemoteMediator.kt
+++ b/app/src/main/java/com/myapps/pruebaandroidtl/moviesfeature/data/paging/MoviesRemoteMediator.kt
@@ -6,7 +6,7 @@ import androidx.paging.PagingState
 import androidx.paging.RemoteMediator
 import com.myapps.pruebaandroidtl.moviesfeature.data.datasource.MoviesDataSource
 import com.myapps.pruebaandroidtl.moviesfeature.data.local.MoviesDao
-import com.myapps.pruebaandroidtl.utils.constants.INITIAL_PAGE
+import com.myapps.pruebaandroidtl.utils.constants.ONE_INT
 import com.myapps.pruebaandroidtl.moviesfeature.domain.models.MovieModel
 import com.myapps.pruebaandroidtl.utils.StateResult
 import javax.inject.Inject
@@ -16,7 +16,7 @@ import javax.inject.Inject
 class MoviesRemoteMediator @Inject constructor(
     private val moviesDao: MoviesDao,
     private val moviesDataSource: MoviesDataSource,
-    private val initialKey: Int = INITIAL_PAGE
+    private val initialKey: Int = ONE_INT
     ) : RemoteMediator<Int, MovieModel>(){
     override suspend fun load(loadType: LoadType, state: PagingState<Int, MovieModel>): MediatorResult {
     return try {

--- a/app/src/main/java/com/myapps/pruebaandroidtl/moviesfeature/data/paging/MoviesRemoteMediator2.kt
+++ b/app/src/main/java/com/myapps/pruebaandroidtl/moviesfeature/data/paging/MoviesRemoteMediator2.kt
@@ -6,7 +6,7 @@ import androidx.paging.PagingState
 import androidx.paging.RemoteMediator
 import com.myapps.pruebaandroidtl.moviesfeature.data.datasource.MoviesDataSource
 import com.myapps.pruebaandroidtl.moviesfeature.data.local.MoviesDao
-import com.myapps.pruebaandroidtl.utils.constants.INITIAL_PAGE
+import com.myapps.pruebaandroidtl.utils.constants.ONE_INT
 import com.myapps.pruebaandroidtl.moviesfeature.domain.models.MovieModel
 import java.io.IOException
 import javax.inject.Inject
@@ -16,7 +16,7 @@ import retrofit2.HttpException
 class MoviesRemoteMediator2 @Inject constructor(
     private val moviesDao: MoviesDao,
     private val moviesDataSource: MoviesDataSource,
-    private val initialKey: Int = INITIAL_PAGE
+    private val initialKey: Int = ONE_INT
 ) : RemoteMediator<Int, MovieModel>(){
 
     override suspend fun initialize(): InitializeAction {

--- a/app/src/main/java/com/myapps/pruebaandroidtl/utils/constants.kt
+++ b/app/src/main/java/com/myapps/pruebaandroidtl/utils/constants.kt
@@ -5,12 +5,18 @@ package com.myapps.pruebaandroidtl.utils.constants
 const val MOVIES_BASE_URL = "https://api.themoviedb.org/3/"
 const val POPULAR_MOVIES_ENDPOINT = "movie/popular"
 const val TMDB_API_KEY = "7aadee8cf97e6e803f7aaab29fb6a65d"
-const val INITIAL_PAGE = 1
+const val ONE_INT = 1
+const val ZERO_INT = 0
 
 //RouteService
 const val ROUTE_SERVICE_BASE_URL = "https://api.openrouteservice.org"
 const val ROUTES_ENDPOINT = "/v2/directions/driving-car?"
 const val RS_API_KEY = "5b3ce3597851110001cf6248e8fcccf880e74f4b8402c5ad0a843825"
+
+//MapsFragment
+const val ROUTE_LINE_WIDTH = 12f
+const val CUSTOM_ZOOM = 12F
+const val EMPTY_STRING = ""
 
 
 

--- a/app/src/main/res/layout/fragment_maps1.xml
+++ b/app/src/main/res/layout/fragment_maps1.xml
@@ -16,21 +16,6 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <TextView
-            android:id="@+id/tv_my_location_address"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:hint="@string/my_address"
-            android:textSize="24sp"/>
-        <TextView
-            android:id="@+id/tv_target_location_address"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:hint="@string/target_location"
-            android:textSize="24sp"/>
-
         <com.google.android.gms.maps.MapView
             android:id="@+id/mapView"
             android:layout_width="match_parent"
@@ -42,12 +27,49 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <Button
+        <androidx.cardview.widget.CardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:cardCornerRadius="16dp"
+            android:layout_margin="8dp"
+            android:elevation="32dp">
+
+            <TextView
+                android:id="@+id/tv_my_location_address"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:hint="@string/my_address"
+                android:textSize="24sp"/>
+
+        </androidx.cardview.widget.CardView>
+
+        <androidx.cardview.widget.CardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:cardCornerRadius="16dp"
+            android:layout_margin="8dp"
+            android:elevation="32dp">
+
+            <TextView
+                android:id="@+id/tv_target_location_address"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:hint="@string/target_location"
+                android:textSize="24sp"/>
+        </androidx.cardview.widget.CardView>
+
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_see_route_info"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/see_route_info"
-            android:enabled="false"/>
+            android:enabled="false"
+            app:cardCornerRadius="16dp"
+            android:layout_margin="8dp"
+            android:elevation="32dp"
+            />
 
     </LinearLayout>
 

--- a/app/src/main/res/navigation/app_nav_graph.xml
+++ b/app/src/main/res/navigation/app_nav_graph.xml
@@ -49,7 +49,7 @@
         android:label="fragment_route_info"
         tools:layout="@layout/fragment_route_info" >
         <argument
-            android:name="time"
+            android:name="routeInfo"
             app:argType="float[]"
             app:nullable="true" />
     </fragment>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,8 +11,11 @@
     <string name="movie_title">MovieTitle</string>
     <string name="overview">Overview</string>
     <string name="label_distance">Distancia: %s1 Km</string>
-    <string name="label_time">Tiempo recorrido en auto: %s1 min</string>
+    <string name="label_time">Tiempo del recorrido en auto: %s1 min</string>
     <string name="distance_hint">Distance</string>
     <string name="time_hint">Time</string>
+    <string name="route_not_found">No se ha encontrado la ruta</string>
+    <string name="wrong_location">No haz ingresado una ubicacion valida</string>
+    <string name="go_to_settings">Ve a ajustes y acepta los permisos</string>
 
 </resources>


### PR DESCRIPTION
# Description

the variables associated with the user's location info and the target location have been relocated to the view model, in order to support the rotation changes of the application.

## Evidence

![image](https://user-images.githubusercontent.com/97921301/198858713-777b2d82-1281-4221-b96c-44493c7545df.png)


![image](https://user-images.githubusercontent.com/97921301/198858720-bb0504cb-c978-4f20-8aa2-b602119bab81.png)

## Type of change

Please delete options that are not relevant.

- [ ] 🐛 Bug fix 
- [ ] 🆕 New feature
- [x] 🌱 Improvement
- [ ] ⬆️ This change requires a documentation update

## Checklist:

- [ ] Include Unit Tests.
- [ ] My code follows the style guidelines of this project
- [x] Just enough, not too much
- [x] [Formatted commit messages](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes